### PR TITLE
fix: play画面修正（画像表示、文字の大きさ、判定ロジック）

### DIFF
--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -11,6 +11,12 @@ export default class extends Controller {
     "totalCount", "totalScore"
   ]
 
+  static values = {
+    mushroomPath: String,
+    bambooPath: String,
+    catPath: String
+  }
+
   connect() {
     this.timeLeft = 15
     this.isGameOver = false
@@ -25,6 +31,28 @@ export default class extends Controller {
     this.startTimer()
     // 出現ループ開始
     this.spawnLoop()
+  }
+
+  getAssetPath(filename) {
+    // Railsのasset_pathで生成されたパスを使用
+    if (filename === "mushroom.png") {
+      return this.mushroomPathValue
+    } else if (filename === "bamboo.png") {
+      return this.bambooPathValue
+    } else if (filename === "cat.png") {
+      return this.catPathValue
+    }
+    return `/assets/${filename}` // フォールバック
+  }
+
+  // メモリリークの防止
+  disconnect() {
+    if (this.timerInterval) {
+      clearInterval(this.timerInterval)
+    }
+    if (this.spawnInterval) {
+      clearInterval(this.spawnInterval)
+    }
   }
 
   startTimer() {
@@ -69,11 +97,11 @@ export default class extends Controller {
     // img要素を生成
     const img = document.createElement("img")
     if (type === "mushroom") {
-      img.src = "/assets/mushroom.png" // Railsがコンパイル後に配信
+      img.src = this.getAssetPath("mushroom.png")
     } else if (type === "bamboo") {
-      img.src = "/assets/bamboo.png"
+      img.src = this.getAssetPath("bamboo.png")
     } else {
-      img.src = "/assets/cat.png"
+      img.src = this.getAssetPath("cat.png")
     }
 
     img.className = "absolute cursor-pointer w-12 h-12" // Tailwindで大きさ指定
@@ -127,7 +155,9 @@ export default class extends Controller {
   getResultCategory() {
     const { mushroom, bamboo, cat, total } = this
 
-    if (mushroom.count > bamboo.count && mushroom.score >= 100) {
+    if (total.score >= 230) {
+      return "秋の支配者 🍠"
+    } else if (mushroom.count > bamboo.count && mushroom.score >= 100) {
       return "きのこマスター 🍄"
     } else if (bamboo.count > mushroom.count && bamboo.score >= 100) {
       return "たけのこ名人 🎋"
@@ -135,8 +165,6 @@ export default class extends Controller {
       return "ねこ様第一主義 🐱"
     } else if (mushroom.count >= 2 && bamboo.count >= 2 && cat.count >= 2) {
       return "バランス王 👑"
-    } else if (total.score >= 200) {
-      return "秋の支配者 🍠"
     } else {
       return "ゆったりお散歩 🚶"
     }

--- a/app/views/games/play.html.erb
+++ b/app/views/games/play.html.erb
@@ -1,43 +1,47 @@
-<div data-controller="game" class="p-6">
+<div data-controller="game"
+     data-game-mushroom-path-value="<%= asset_path('mushroom.png') %>"
+     data-game-bamboo-path-value="<%= asset_path('bamboo.png') %>"
+     data-game-cat-path-value="<%= asset_path('cat.png') %>"
+     class="p-6">
 <h1 class="row-start-3 text-center text-2xl font-bold pt-4">きのこたけのこにゃんこをタッチ!</h1>
 <div class="overflow-x-auto py-2">
-  <table class="table table-sm">
+  <table class="table table-sm lg:text-xl">
     <thead>
       <tr>
-        <th></th>
-        <th>Get!</th>
-        <th>カウント</th>
-        <th>得点</th>
-        <th>説明</th>
+        <th class="lg:text-xl"></th>
+        <th class="lg:text-xl">Get!</th>
+        <th class="lg:text-xl">カウント</th>
+        <th class="lg:text-xl">得点</th>
+        <th class="lg:text-xl">説明</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th></th>
-        <th>合計</th>
-        <td class="text-blue-600" data-game-target="totalCount">0</td>
-        <td><span data-game-target="totalScore">0</span>点</td>
+        <th class="lg:text-xl"></th>
+        <th class="lg:text-xl">合計</th>
+        <td class="text-blue-600 lg:text-xl" data-game-target="totalCount">0</td>
+        <td class="lg:text-xl"><span data-game-target="totalScore">0</span>点</td>
       </tr>
       <tr>
-        <th></th>
-        <th>きのこ</th>
-        <td class="text-green-600" data-game-target="mushroomCount">0</td>
-        <td><span data-game-target="mushroomScore">0</span>点</td>
-        <td>1つにつき15点</td>
+        <th class="lg:text-xl"></th>
+        <th class="lg:text-xl">きのこ</th>
+        <td class="text-green-600 lg:text-xl" data-game-target="mushroomCount">0</td>
+        <td class="lg:text-xl"><span data-game-target="mushroomScore">0</span>点</td>
+        <td class="lg:text-xl">1つにつき15点</td>
       </tr>
       <tr>
-        <th></th>
-        <th>たけのこ</th>
-        <td class="text-yellow-600" data-game-target="bambooCount">0</td>
-        <td><span data-game-target="bambooScore">0</span>点</td>
-        <td>1つにつき15点</td>
+        <th class="lg:text-xl"></th>
+        <th class="lg:text-xl">たけのこ</th>
+        <td class="text-yellow-600 lg:text-xl" data-game-target="bambooCount">0</td>
+        <td class="lg:text-xl"><span data-game-target="bambooScore">0</span>点</td>
+        <td class="lg:text-xl">1つにつき15点</td>
       </tr>
       <tr>
-        <th></th>
-        <th>にゃんこ</th>
-        <td class="text-pink-600" data-game-target="catCount">0</td>
-        <td><span data-game-target="catScore">0</span>点</td>
-        <td>可愛いので1匹につき28点 ただし可愛いので2秒減る</td>
+        <th class="lg:text-xl"></th>
+        <th class="lg:text-xl">にゃんこ</th>
+        <td class="text-pink-600 lg:text-xl" data-game-target="catCount">0</td>
+        <td class="lg:text-xl"><span data-game-target="catScore">0</span>点</td>
+        <td class="lg:text-xl">可愛いので1匹につき28点 ただし可愛いので2秒減る</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
# 概要
- ゲームプレイ画面について、以下の修正を行いました。
  - 本番環境できのこ・たけのこ・ねこの表示がされなかったため、ビュー・Stimulusコントローラーを修正しました。
    1. HTMLビュー (play.html.erb):
    Railsのasset_pathヘルパーを使用してdata属性に正しいパスを設定
    2. Stimulusコントローラー: data属性のvalueを受け取り、画像パスとして使用
- 画面上部の配点説明テーブルの文字を大きくしました（スマホ画面は変更なし）。
- 結果のカテゴリ判定ロジックを変更しました。